### PR TITLE
Fix mixed HTTPS/HTTP content

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://c2.com/wiki/closed.html
 
 # Process
 We will focus on restoring some service as soon as possible. Then advance a broader agenda in several more stages.
-Throughtout our remodel we will focus on simple implementation with minimum dependencies
+Throughout our remodel we will focus on simple implementation with minimum dependencies
 requiring the least attention in years ahead.
 
 - [return wiki to 95% service](https://github.com/WardCunningham/remodeling/issues/1) ✔︎

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ We're rewriting the original wiki as a single-page application.
 Write privileges were withdrawn in 2015 after a disgruntled visitor threatened automated destruction.
 We described the situation then in one of our usual system notices.
 
-http://wiki.c2.com/?WikiWikiSystemNotice
+https://wiki.c2.com/?WikiWikiSystemNotice
 
 We were closed completely for one week this year with the following explanation. We're open now and continuing to improve.
 
-http://c2.com/wiki/closed.html
+https://c2.com/wiki/closed.html
 
 # Process
 We will focus on restoring some service as soon as possible. Then advance a broader agenda in several more stages.
@@ -24,4 +24,4 @@ We have a new site running and available for browsing.
 Review our checklists above to align your expectations.
 We're aware of missing data and all formatting is provisional.
 
-http://wiki.c2.com/?WelcomeVisitors
+https://wiki.c2.com/?WelcomeVisitors

--- a/static/compare.html
+++ b/static/compare.html
@@ -1,11 +1,11 @@
 <table><tr>
 <td><iframe id=a src="/?WelcomeVisitors" width=400 height=1000></iframe></td>
-<td><iframe id=b src="http://c2.com/cgi/wikix?WelcomeVisitors" width=400 height=1000></iframe></td>
+<td><iframe id=b src="https://c2.com/cgi/wikix?WelcomeVisitors" width=400 height=1000></iframe></td>
 </table>
 <script>
   prefix = location.pathname.replace(/[^\/]*$/, '')
   a.src = prefix + location.search
-  b.src = 'http://c2.com/cgi/wikix' + location.search
+  b.src = 'https://c2.com/cgi/wikix' + location.search
 </script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript"></script>
+<script src="https://www.google-analytics.com/urchin.js" type="text/javascript"></script>
 <script type="text/javascript">_uacct = "UA-2377314-2";_udn="c2.com"; urchinTracker();</script>

--- a/static/index.html
+++ b/static/index.html
@@ -136,7 +136,7 @@
     }
     function external (url) {
       if (url.match(/\.(gif|jpg|jpeg|png)$/)) {
-        return stash("<img src=\"" + url.replace(/^http:\/wiki\//,'http://c2.com/wiki/') + "\">")
+        return stash("<img src=\"" + url.replace(/^https:\/wiki\//,'https://c2.com/wiki/') + "\">")
       } else {
         return stash("<a href=\"" + url + "\" rel=\"nofollow\" target=\"_blank\">" + url + "</a>")
       }
@@ -144,17 +144,17 @@
     function youtube (match, p1, p2) {
       var embed =
         "<object width=\"425\" height=\"344\">" +
-        "<param name=\"movie\" value=\"http://www.youtube.com/v/$2&hl=en&fs=1&\"></param>" +
+        "<param name=\"movie\" value=\"https://www.youtube.com/v/$2&hl=en&fs=1&\"></param>" +
         "<param name=\"allowFullScreen\" value=\"true\"></param>" +
         "<param name=\"allowscriptaccess\" value=\"always\"></param>" +
-        "<embed src=\"http://www.youtube.com/v/" + p2 + "&hl=en&fs=1&\" type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\" width=\"425\" height=\"344\"></embed>" +
+        "<embed src=\"https://www.youtube.com/v/" + p2 + "&hl=en&fs=1&\" type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\" width=\"425\" height=\"344\"></embed>" +
         "</object>"
       return stash(embed)
     }
     function isbn (match, isbn) {
       var code = isbn.replace(/[- ]/g, "")
       if (code.match(/^\d{9}.$/)) {
-        return stash("<a href=\"http://www.amazon.com/exec/obidos/ISBN=" + code + "/portlandpatternrA/\" rel=\"nofollow\">ISBN " + isbn + "</a>")
+        return stash("<a href=\"https://www.amazon.com/exec/obidos/ISBN=" + code + "/portlandpatternrA/\" rel=\"nofollow\">ISBN " + isbn + "</a>")
       } else {
         return "ISBN " + isbn
       }
@@ -183,11 +183,11 @@
       return stash("<input type=text id=search onInput='get()' onKeyPress='got()'><br><div id=searchresult></div>")
     }
     function fullsearch () {
-      return stash("<form action=\"http://c2.com/cgi/fullSearch\"><input type=text name=search></form>")
+      return stash("<form action=\"https://c2.com/cgi/fullSearch\"><input type=text name=search></form>")
     }
     var prepass = text
       .replace(/〖(\d+)〗/g, '〖 $1 〗')
-      .replace(/^http:\/\/(www.)?youtube.com\/watch\?v=([-\w]+)/, youtube)
+      .replace(/^https:\/\/(www.)?youtube.com\/watch\?v=([-\w]+)/, youtube)
       .replace(/\[Search\]/, titlesearch)
       .replace(/\[Fullsearch\]/, fullsearch)
       .replace(/\[?ISBN:? *([0-9- xX]{10,})\]?/i, isbn)
@@ -222,7 +222,7 @@
     var words = document.title = title.replace(/([a-z])([A-Z])/g, '$1 $2');
     return [
       '<h1><img src=wiki.gif><div><span>',
-      '<a href="http://c2.com/cgi/fullSearch?search=' + title + '" rel=nofollow>' + words + '</a>',
+      '<a href="https://c2.com/cgi/fullSearch?search=' + title + '" rel=nofollow>' + words + '</a>',
       '</span></div></h1>'
     ].join('')
   }
@@ -266,7 +266,7 @@
   }
   function fetchPage (done) {
     title = (location.search.match(/\w+/)||["WelcomeVisitors"])[0]
-    var database = 'http://c2.com/wiki/remodel/pages/'
+    var database = 'https://c2.com/wiki/remodel/pages/'
     loadDoc(database + title, done)
   }
   function init() {
@@ -287,7 +287,7 @@
 
 </script>
 <script async defer src="https://hypothes.is/embed.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript"></script>
+<script src="https://www.google-analytics.com/urchin.js" type="text/javascript"></script>
 <script type="text/javascript">_uacct = "UA-2377314-2";_udn="c2.com"; urchinTracker();</script>
 
 </body>


### PR DESCRIPTION
Modern browsers will block all HTTP requests from a HTTPS loaded page. This PR fixes that issue by using HTTPS links everywhere.