### PR TITLE
fix troublesome pages

### DIFF
--- a/check.pl
+++ b/check.pl
@@ -1,0 +1,8 @@
+# remove separators before checking for other invalid characters
+# usage: cat file perl check.pl | ruby check.rb
+
+my $SEP = "\263";
+$_ = join('', <STDIN>);
+s/\o{347}/c/g;
+s/\o{222}/'/g;
+print join('<<<<gs>>>>',split($SEP, $_));

--- a/check.rb
+++ b/check.rb
@@ -1,0 +1,13 @@
+# see if ruby will complain reading input
+# usage: cat file | perl check.rb | ruby check.rb
+
+Encoding.default_external = Encoding::UTF_8
+i = 0
+while x = $stdin.gets
+  begin
+    i += 1
+    x.scan(/e/)
+  rescue Exception => e
+    puts "#{i} #{x}"
+  end
+end

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,8 @@
+# check all remaining pages with trouble
+# sh check.sh; ls -lSr invalid
+
+cat pages/* | \
+  jq -r 'select(.trouble)|.page' | \
+  while read i; do
+    cat trouble/$i | perl check.pl | ruby check.rb > invalid/$i
+  done

--- a/json.pl
+++ b/json.pl
@@ -1,0 +1,14 @@
+# extract specific fields from legacy wiki format files
+# usage: cat PageName | perl json.pl date rev text
+
+my $SEP = "\263";
+$_ = join('', <STDIN>);
+s/\o{347}/c/g;
+s/\o{222}/'/g;
+%fields = split $SEP, $_;
+@selected = ();
+for (@ARGV) {
+  push @selected, $_;
+  push @selected, $fields{$_};
+}
+print join '<<<<gs>>>>', @selected;

--- a/json.rb
+++ b/json.rb
@@ -5,17 +5,39 @@ require 'json'
 
 Encoding.default_external = Encoding::UTF_8
 
-def get file
-  raw = `cat #{file} | ./a.out`
-  it = Hash[raw.split(/<<<<gs>>>>/).each_slice(2).to_a]
-  {date:it['date'], text:it['text']}
-rescue Exception => e
-  {}
+@text = @copy = @trouble = 0
+
+def sep text
+  Hash[text.split(/<<<<gs>>>>/).each_slice(2).to_a]
 end
 
-Dir.glob('wiki.wdb/*') do |file|
-  File.open(file.gsub(/wiki.wdb/, 'static/pages'),'w') do |output|
-    output.puts JSON.pretty_generate(get(file))
-  end
+def get page
+  it = sep `cat trouble/#{page} | perl json.pl date text rev`
   print '.'
+  @text += 1
+  {date:it['date'], text:it['text'], rev:it['rev'], page:page}
+rescue Exception => e
+  begin
+    it = sep `cat trouble/#{page} | perl json.pl date copy rev`
+    raise 'missing' if it['copy'].empty?
+    print ','
+    @copy += 1
+    {date:it['date'], text:it['copy'], rev:it['rev'], page:page, copy: true}
+  rescue Exception => e
+    print 'x'
+    @trouble += 1
+    {page:page, trouble:true}
+  end
 end
+
+Dir.glob('trouble/*') do |file|
+  page = file.gsub(/trouble\//, '')
+  File.open("pages/#{page}",'w') do |output|
+    output.puts JSON.pretty_generate(get(page))
+  end
+end
+
+puts
+puts "#{@text} text ok"
+puts "#{@copy} copy ok"
+puts "#{@trouble} with trouble"


### PR DESCRIPTION
We add some tools for finding and correcting character code problems. Rather than work on the whole wiki database, we select out troublesome pages into a `trouble` directory. As we improve our json.* script chain we will produce possibly improved pages in a `pages` directory. From this we can select out specific remaining problems which we diagnose at the line level and collect in the `invalid` directory. From this we inspect the octal characters and find substitutions then repeat the process looking for improvements.

# bulk convert

```
ruby json.rb
```
This reports progress on individual files using the codes `.`, `,` and `x` for retrieved text, copy or still trouble. Counts will measure progress.
```text
x......x..,x...xx.xx....,..xxxx.xx..x..x...x..xx.x..x,x.x.xx.x,x.x...xx.,.x.x,..
.........x.....,..x,x..x.....xx..x...........x......xx..x...xxx...xx........xxx,
..x,.x.xx..x.....x...x.x.xxxxxx.xx.x,..x.x,x.x,x.xxx,....,x.xx.x.xxx.x.x,...xxx.
......,xx...x.,x.x..xx.x,.x,.x,xx..x,.x.x.xx.x.xxxx.xx...............xx..x..x.x.
x.x..x..x..xxxxx.x...x.x.x...x...xxxxx.xxxx..x.x...xx.....x.,x.x.xx...x.x.......
xxx..,..,,.x..x..,x,x..x.x..x..x.xx.x,x.x...x.,.x.xxxxxx..xx....,..,x..xx......x
,.xx..x.xx.,........xxxx...xx..,.xx..xxx.x..,x.,x,.....x.xx,xxx...x..x...xx..xxx
.x....xxxxxxx,x..xxxxxx....xx..xx.xxx......x....x..xx,xxx,xx..x...xxxxx..x....x.
x,..xx.xx,.....x.,.x.x.,x..x.x.,x,...x....x..,..xxx.xxxx.x...x.x.x.x.....x.x.xxx
..x..,.xxx..x..xx.x.x..x,.,x.,x,x.....x.xx....xxx.x..x.x,.x.xx....x...xx..x..x.x
...x..x.xx.xxx.x.xx...x...xx..x.xxx...xxxx...xxx,,x,.x,,..xx...xx...x...,x..x...
xxx,xx.xxx,..xx.x.,xx.xx,.xxxx...xxxx,.xx.x.x.xx,x..xxxxxxxx..xxxxx.,.,,x....xxx
x.x..xx.x.x...xx,..x....xx..x.x,,x..xx....x..,x..,x,x.x.x..x.........x.,...xxxx.
....x.x.x..x.xx..xxxxxx..xx.,.
557 text ok
78 copy ok
435 with trouble
```
# diagnosis

```
rm invalid/*
cat pages/* | \
  jq -r 'select(.trouble)|.page' | \
  while read i; do
    cat trouble/$i | perl check.pl | ruby check.rb > invalid/$i
  done
```
A typical invalid file shows numbered lines with invalid characters.
```
cat invalid/AmbientOrb
24 "Automated Continuous Integration and the Ambient Orb™"
75 "Automated Continuous Integration and the Ambient Orb™"
```
Good technique is to flip through the reports working from the shortest entries first.
```
(cd invalid; for i in `ls -Sr`; do echo $i; cat $i; echo;  read x; done)
```
When a particular line of a particular file is of interest, isolate that line and dumb it in octal.
```
cat invalid/AmbientOrb | head -24 | tail -1 | od -c
0000000    7   5       "   A   u   t   o   m   a   t   e   d       C   o
0000020    n   t   i   n   u   o   u   s       I   n   t   e   g   r   a
0000040    t   i   o   n       a   n   d       t   h   e       A   m   b
0000060    i   e   n   t       O   r   b 231   "  \r  \n  
```
In this case the invalid character is octal 231.
# subsititution
Perl is happy to change these characters to something preferable. In this case, the `tm` is probably a joke and won't be missed. 
```
s/\o{231}//g;
```
These commands go into `json.pl` and `check.pl` which have a similar structure. We repeat from the beginning and find less work to do. (In this case, way less work todo having worked a few substitutions before repeating.)
```
624 text ok
69 copy ok
377 with trouble
```
