### PR TITLE
Drop Hypothesis

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -286,7 +286,6 @@
   init()
 
 </script>
-<script async defer src="https://hypothes.is/embed.js"></script>
 <script src="https://www.google-analytics.com/urchin.js" type="text/javascript"></script>
 <script type="text/javascript">_uacct = "UA-2377314-2";_udn="c2.com"; urchinTracker();</script>
 


### PR DESCRIPTION
We have no way to know if hypothesis is being used. We think not. And we suspect it to be causing security violations with some releases of Firefox. See #40